### PR TITLE
implemented clean command for docker resource cleanup

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/Naganathan05/Load-Pulse/utils"
+	"github.com/spf13/cobra"
+);
+
+var cleanCmd = &cobra.Command{
+	Use:   "clean",
+	Short: "Clean up containers",
+	Long:  "Clean up containers and other associated resources",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.LogInfo("Starting cleanup process ...");
+
+		out, err := exec.Command("docker", "compose", "ps", "-q").Output();
+		if err != nil || len(out) == 0 {
+			utils.LogInfo("No containers found to clean up");
+			return;
+		};
+
+		stopCmd := exec.Command("docker", "compose", "down", "-v");
+
+		if err := stopCmd.Run(); err != nil {
+			utils.LogError("Failed to stop containers with Docker Compose: " + err.Error());
+			os.Exit(1);
+		};
+
+		utils.LogInfo("Container Cleanup Successfully Completed");
+	},
+};
+
+func init() {
+	rootCmd.AddCommand(cleanCmd);
+};

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
-	"os"
 	"fmt"
-	"time"
+	"os"
 	"os/exec"
-	"github.com/spf13/cobra"
+	"time"
+
 	"github.com/briandowns/spinner"
-	
+	"github.com/spf13/cobra"
+
 	"github.com/Naganathan05/Load-Pulse/utils"
 )
 
@@ -54,6 +55,8 @@ var runCmd = &cobra.Command{
 		logsCmd.Stdout = os.Stdout;
 		logsCmd.Stderr = os.Stderr;
 		logsCmd.Run();
+
+		cleanCmd.Run(cmd, args);
 	},
 }
 


### PR DESCRIPTION
## Added `clean` command
Runs `docker compose down -v` : the -v is for removing volumes
- clean up only happens if there are any existing containers