### PR TITLE
Improve error handling in cluster and leader modules

### DIFF
--- a/internals/Load-Tester/Raft/cluster.go
+++ b/internals/Load-Tester/Raft/cluster.go
@@ -20,6 +20,10 @@ func Run(b *Service.Bench) {
 	for testerIndex, tester := range b.Testers {
 		totalRequests := tester.Conns * int(tester.Dur.Seconds()) / int(tester.Rate.Milliseconds());
 		numWorkersPerCluster := Service.Min(cfg.ClusterSize, totalRequests);
+		if numWorkersPerCluster == 0 {
+            log.Printf("[ERROR]: numWorkersPerCluster is zero, skipping tester %d\n", testerIndex+1);
+            continue;
+        }
 		numClusters := totalRequests / numWorkersPerCluster;
 
 		requestsPerWorker := totalRequests / numWorkersPerCluster;

--- a/internals/Load-Tester/Raft/leader.go
+++ b/internals/Load-Tester/Raft/leader.go
@@ -51,7 +51,11 @@ func StartLeader(id int, tester *Service.LoadTester, workerCnt int, maxRequests 
 		leader.stats.Unlock();
 	}
 
-	statsJSON, _ := json.Marshal(leader.stats);
+	statsJSON, errors := json.Marshal(leader.stats);
+	if errors != nil {
+        Service.LogError(fmt.Sprintf("[LEADER-%d]: Failed to marshal stats: %v\n", leader.id, errors))
+        return
+    }
 	leaderMsg := fmt.Sprintf("[LEADER-%d]: Publishing Stats to Queue: %s\n", leader.id, queueName);
 	Service.LogLeader(leaderMsg);
 


### PR DESCRIPTION
1) In cluster.go If numWorkersPerCluster is zero, dividing by it will panic and crash the program. 
2) In leader.go added error  handling for marshalling  in case marshal fails.