### PR TITLE
refactor: migrate load generator from net/http to fasthttp

### DIFF
--- a/internals/Load-Tester/Raft/tester.go
+++ b/internals/Load-Tester/Raft/tester.go
@@ -1,34 +1,38 @@
 package Raft
 
 import (
-	"io"
 	// "fmt"
 	"time"
-	
+
+	"github.com/valyala/fasthttp"
+
 	"Load-Pulse/Config"
 	"Load-Pulse/Service"
 	"Load-Pulse/Statistics"
 )
 
 func RunTest(workerID int, l *Service.LoadTester) *Statistics.Stats {
-	var body []byte;
-	start := time.Now();
+	start := time.Now()
 
-	cfg := Config.GetConfig();
-	requestSleepTime := cfg.RequestSleepTime;
+	cfg := Config.GetConfig()
+	requestSleepTime := cfg.RequestSleepTime
 
-	currConcurrencyCount := Service.GetRequestCount();
+	currConcurrencyCount := Service.GetRequestCount()
 	for currConcurrencyCount > int64(l.ConcurrencyLimit) {
 		// workerMsg := fmt.Sprintf("[WORKER-ALERT-%d]: Concurrency Count: %d => Limit Reached !! Waiting\n", workerID, currConcurrencyCount);
 		// Service.LogError(workerMsg);
-		time.Sleep(time.Millisecond * time.Duration(requestSleepTime));
-		currConcurrencyCount = Service.GetRequestCount();
+		time.Sleep(time.Millisecond * time.Duration(requestSleepTime))
+		currConcurrencyCount = Service.GetRequestCount()
 	}
 
-	Service.IncrementRequestCount();
+	Service.IncrementRequestCount()
 
-	resp, err := l.Client.Do(l.Request);
-	rd := time.Since(start);
+	req := fasthttp.AcquireRequest()
+	l.Request.CopyTo(req)
+	resp := fasthttp.AcquireResponse()
+
+	err := l.Client.Do(req, resp)
+	rd := time.Since(start)
 
 	stats := &Statistics.Stats{
 		Endpoint:       l.Endpoint,
@@ -38,15 +42,18 @@ func RunTest(workerID int, l *Service.LoadTester) *Statistics.Stats {
 	}
 
 	if err != nil {
-		stats.FailedRequests = 1;
-		Service.DecrementRequestCount();
-		return stats;
+		stats.FailedRequests = 1
+		Service.DecrementRequestCount()
+		fasthttp.ReleaseRequest(req)
+		fasthttp.ReleaseResponse(resp)
+		return stats
 	}
 
-	defer resp.Body.Close();
+	stats.ResponseSize = float64(len(resp.Body()))
 
-	body, _ = io.ReadAll(resp.Body);
-	stats.ResponseSize = float64(len(body));
-	Service.DecrementRequestCount();
-	return stats;
+	fasthttp.ReleaseRequest(req)
+	fasthttp.ReleaseResponse(resp)
+
+	Service.DecrementRequestCount()
+	return stats
 }

--- a/internals/Load-Tester/go.mod
+++ b/internals/Load-Tester/go.mod
@@ -1,19 +1,25 @@
 module Load-Pulse/Load-Tester
 
-go 1.22.5
+go 1.24.0
+
+toolchain go1.24.5
 
 require (
 	Load-Pulse/Config v0.0.0
 	Load-Pulse/Service v0.0.0
 	Load-Pulse/Statistics v0.0.0
+	github.com/valyala/fasthttp v1.68.0
 )
 
 require (
+	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
+	github.com/klauspost/compress v1.18.1 // indirect
 	github.com/redis/go-redis/v9 v9.7.3 // indirect
 	github.com/streadway/amqp v1.1.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
 )
 
 replace Load-Pulse/Aggregator => ../Aggregator

--- a/internals/Load-Tester/go.sum
+++ b/internals/Load-Tester/go.sum
@@ -1,3 +1,5 @@
+github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
+github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -8,7 +10,15 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/klauspost/compress v1.18.1 h1:bcSGx7UbpBqMChDtsF28Lw6v/G94LPrrbMbdC3JH2co=
+github.com/klauspost/compress v1.18.1/go.mod h1:ZQFFVG+MdnR0P+l6wpXgIL4NTtwiKIdBnrBd8Nrxr+0=
 github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
 github.com/streadway/amqp v1.1.0 h1:py12iX8XSyI7aN/3dUT8DFIDJazNJsVJdxNVEpnQTZM=
 github.com/streadway/amqp v1.1.0/go.mod h1:WYSrTEYHOXHd0nwFeUXAe2G2hRnQT+deZJJf88uS9Bg=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasthttp v1.68.0 h1:v12Nx16iepr8r9ySOwqI+5RBJ/DqTxhOy1HrHoDFnok=
+github.com/valyala/fasthttp v1.68.0/go.mod h1:5EXiRfYQAoiO/khu4oU9VISC/eVY6JqmSpPJoHCKsz4=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=

--- a/internals/Service/bench.go
+++ b/internals/Service/bench.go
@@ -1,10 +1,9 @@
 package Service
 
 import (
-	"io"
 	"time"
-	"bytes"
-	"net/http"
+
+	"github.com/valyala/fasthttp"
 
 	"Load-Pulse/Statistics"
 )
@@ -17,8 +16,8 @@ type Bench struct {
 type LoadTester struct {
 	Endpoint         string
 	Conns            int
-	Request          *http.Request
-	Client           *http.Client
+	Request          *fasthttp.Request
+	Client           *fasthttp.Client
 	Stats            *Statistics.Stats
 	Dur              time.Duration
 	Rate             time.Duration
@@ -39,11 +38,11 @@ func Max(a int, b int) int {
 	return b;
 }
 
-func NewTester(r *http.Request, conns int, dur, rate time.Duration, end string, concurrencyLimit int) *LoadTester {
+func NewTester(r *fasthttp.Request, conns int, dur, rate time.Duration, end string, concurrencyLimit int) *LoadTester {
 	return &LoadTester{
 		Endpoint:         end,
 		Request:          r,
-		Client:           &http.Client{},
+		Client:           &fasthttp.Client{},
 		Conns:            conns,
 		Dur:              dur,
 		Rate:             rate,
@@ -61,16 +60,14 @@ func NewLoadTester(path string) (*Bench, error) {
 	}
 
 	for _, req := range conf.Req {
-		var buf io.Reader;
-		addr := conf.Host + req.Endpoint;
+		addr := conf.Host + req.Endpoint
+
+		r := &fasthttp.Request{}
+		r.SetRequestURI(addr)
+		r.Header.SetMethod(req.Method)
 
 		if req.Data != "" {
-			buf = bytes.NewBufferString(req.Data);
-		}
-
-		r, err := http.NewRequest(req.Method, addr, buf);
-		if err != nil {
-			return nil, err;
+			r.SetBodyString(req.Data)
 		}
 
 		lt := NewTester(r, req.Connections, conf.Duration*time.Second, req.Rate*time.Millisecond, req.Endpoint, req.ConcurrencyLimit);

--- a/internals/Service/go.mod
+++ b/internals/Service/go.mod
@@ -1,18 +1,24 @@
 module Load-Pulse/Service
 
-go 1.22.5
+go 1.24.0
+
+toolchain go1.24.5
 
 require (
 	Load-Pulse/Config v0.0.0
 	Load-Pulse/Statistics v0.0.0-00010101000000-000000000000
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/streadway/amqp v1.1.0
+	github.com/valyala/fasthttp v1.68.0
 )
 
 require (
+	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
+	github.com/klauspost/compress v1.18.1 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
 )
 
 replace Load-Pulse/Config => ../Config

--- a/internals/Service/go.sum
+++ b/internals/Service/go.sum
@@ -1,3 +1,5 @@
+github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
+github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -8,7 +10,15 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/klauspost/compress v1.18.1 h1:bcSGx7UbpBqMChDtsF28Lw6v/G94LPrrbMbdC3JH2co=
+github.com/klauspost/compress v1.18.1/go.mod h1:ZQFFVG+MdnR0P+l6wpXgIL4NTtwiKIdBnrBd8Nrxr+0=
 github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
 github.com/streadway/amqp v1.1.0 h1:py12iX8XSyI7aN/3dUT8DFIDJazNJsVJdxNVEpnQTZM=
 github.com/streadway/amqp v1.1.0/go.mod h1:WYSrTEYHOXHd0nwFeUXAe2G2hRnQT+deZJJf88uS9Bg=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasthttp v1.68.0 h1:v12Nx16iepr8r9ySOwqI+5RBJ/DqTxhOy1HrHoDFnok=
+github.com/valyala/fasthttp v1.68.0/go.mod h1:5EXiRfYQAoiO/khu4oU9VISC/eVY6JqmSpPJoHCKsz4=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=


### PR DESCRIPTION
Migrated the load generation client from net/http to fasthttp to improve performance and reduce memory allocations. This involved updating the LoadTester service to use fasthttp types and refactoring the execution loop to implement a zero-allocation pattern with request object pooling and copying for thread safety.