### PR TITLE
feat: add CI/CD workflow for automated Docker image releases

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,93 @@
+name: Build and Publish Docker Images on Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME_AGGREGATOR: ${{ github.repository_owner }}/load-pulse-aggregator
+  IMAGE_NAME_LOAD_TESTER: ${{ github.repository_owner }}/load-pulse-load-tester
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Aggregator
+        id: meta-aggregator
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_AGGREGATOR }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Aggregator Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./internals/Aggregator/Dockerfile
+          push: true
+          tags: ${{ steps.meta-aggregator.outputs.tags }}
+          labels: ${{ steps.meta-aggregator.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Extract metadata for Load-Tester
+        id: meta-load-tester
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOAD_TESTER }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Load-Tester Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./internals/Load-Tester/Dockerfile
+          push: true
+          tags: ${{ steps.meta-load-tester.outputs.tags }}
+          labels: ${{ steps.meta-load-tester.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image build summary
+        run: |
+          echo "### Docker Images Published :rocket:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Aggregator Image:**" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta-aggregator.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Load-Tester Image:**" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta-load-tester.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Images are available at: https://github.com/${{ github.repository }}/pkgs/container" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
[COMPLETED]

Added GitHub Actions workflow to automatically build and publish Docker images on release.
## Changes
- Created [.github/workflows/docker-release.yml]
- Workflow triggers when a new release is published
- Builds Aggregator and Load-Tester Docker images
- Pushes images to GitHub Container Registry (ghcr.io)
- Tags images with semantic versioning (v1.0.0, v1.0, v1, latest)
## Testing
- YAML syntax validated
- Dockerfile paths verified

Closes #16
@Naganathan05 @Hariprasath8064