### PR TITLE
Add --verbose (-v) flag for detailed logging in run command

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -9,7 +9,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Naganathan05/Load-Pulse/utils"
+	
 )
+var verbose bool
 
 var testConfigPath string
 
@@ -17,7 +19,11 @@ var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run the load testing tool",
 	Run: func(cmd *cobra.Command, args []string) {
-		LogInfo("Initializing Load Pulse")
+		if verbose {
+	        LogInfo("Initializing Load Pulse")
+	        LogInfo("Docker compose command started")
+}
+
 		LogInfo("Using testConfig configuration file: " + testConfigPath)
 		ok, _ := utils.IsDockerRunning()
 		if !ok {
@@ -76,5 +82,12 @@ func init() {
 		"c",
 		"testConfig.json",
 		"Path to testConfig configuration file",
+	)
+     runCmd.Flags().BoolVarP(
+		&verbose,
+		"verbose",
+		"v",
+		false,
+		"Enable verbose logging",
 	)
 }


### PR DESCRIPTION
@Naganathan05 
Added a --verbose (-v) flag to the run command to enable more detailed execution logging.

I tested the change locally and confirmed that the verbose logs are printed as expected (screenshot attached).
The run exits at the existing Docker daemon validation step since Docker Desktop is not running on my system; this behavior is unchanged and not related to the flag itself.

Please let me know if any additional validation is required.
![Load-Pulse proof](https://github.com/user-attachments/assets/04106754-a461-4579-9bfa-b7209a445036)
