### PR TITLE
Add user docs Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-user-docs.yml
+++ b/.github/workflows/deploy-user-docs.yml
@@ -1,0 +1,66 @@
+name: Deploy User Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'User-docs/**'
+      - '.github/workflows/deploy-user-docs.yml'
+  pull_request:
+    paths:
+      - 'User-docs/**'
+      - '.github/workflows/deploy-user-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build VitePress docs
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: User-docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: User-docs/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build docs
+        run: npm run docs:build
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: User-docs/docs/.vitepress/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Closes #27.

/assign

## Summary
- Added a GitHub Actions workflow that builds the VitePress user docs when `User-docs/` or the workflow changes.
- Deploys the built `User-docs/docs/.vitepress/dist` artifact to GitHub Pages on pushes to `main` and manual dispatches.
- Keeps pull requests as build-only checks so docs changes can be validated before deployment.

## Verification
- `npm ci`
- `npm run docs:build`
- `git diff --check`